### PR TITLE
feat(popup): add on/off toggle for template match indicator

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -335,6 +335,12 @@
           <button class="toggle-btn" id="close-button-big-toggle" data-on="true">ON</button>
         </div>
       </div>
+      <div class="setting-group">
+        <div class="setting-row">
+          <span id="popup-paint-guide-label">Template Match Indicator</span>
+          <button class="toggle-btn" id="paint-guide-toggle" data-on="true">ON</button>
+        </div>
+      </div>
 
       <!-- Processing (GPU/CPU - keep as select) -->
       <div class="setting-group">

--- a/src/content.ts
+++ b/src/content.ts
@@ -180,6 +180,17 @@ const initializeMainFeatures = async () => {
     "*",
   );
 
+  const { loadPaintGuideFromStorage, getPaintGuide } =
+    await import("@/states/paint-guide");
+  await loadPaintGuideFromStorage();
+  window.postMessage(
+    {
+      source: "mr-wplace-paint-guide-update",
+      enabled: getPaintGuide(),
+    },
+    "*",
+  );
+
   const { loadOverlayLightweightModeFromStorage, getOverlayLightweightMode } =
     await import("@/states/overlay-lightweight-mode");
   await loadOverlayLightweightModeFromStorage();
@@ -299,6 +310,17 @@ const registerMessageListeners = () => {
       window.postMessage(
         {
           source: "mr-wplace-front-tile-layer-update",
+          enabled: message.enabled,
+        },
+        "*",
+      );
+      return;
+    }
+
+    if (message.type === "PAINT_GUIDE_CHANGED") {
+      window.postMessage(
+        {
+          source: "mr-wplace-paint-guide-update",
           enabled: message.enabled,
         },
         "*",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -631,4 +631,5 @@ Do not use this feature to paint actual pixels.`,
   draft_brush: "Brush",
   draft_map_lock: "Lock map (drag to draw)",
   hint_draft_fab_btn: "Draft freely on the map without spending charges",
+  popup_paint_guide: "Template Match Indicator",
 };

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -615,4 +615,5 @@ export const esTranslations = {
   draft_brush: "Pincel",
   draft_map_lock: "Bloquear mapa (arrastrar para dibujar)",
   hint_draft_fab_btn: "Dibuja libremente en el mapa sin gastar cargas",
+  popup_paint_guide: "Indicador de coincidencia de plantilla",
 };

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -622,4 +622,5 @@ export const frTranslations = {
   draft_brush: "Pinceau",
   draft_map_lock: "Verrouiller la carte (glisser pour dessiner)",
   hint_draft_fab_btn: "Esquissez librement sur la carte sans consommer de charges",
+  popup_paint_guide: "Indicateur de correspondance du modèle",
 };

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -634,4 +634,5 @@ export const jaTranslations = {
   draft_brush: "ブラシ",
   draft_map_lock: "マップ固定 (ドラッグで描画)",
   hint_draft_fab_btn: "チャージを消費せず地図に自由に下書きできます",
+  popup_paint_guide: "テンプレ一致インジケーター",
 };

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -606,4 +606,5 @@ export const ptTranslations = {
   draft_brush: "Pincel",
   draft_map_lock: "Bloquear mapa (arraste para desenhar)",
   hint_draft_fab_btn: "Rascunhe livremente no mapa sem gastar cargas",
+  popup_paint_guide: "Indicador de correspondência do modelo",
 };

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -618,4 +618,5 @@ export const ruTranslations = {
   draft_brush: "Кисть",
   draft_map_lock: "Заблокировать карту (рисование перетаскиванием)",
   hint_draft_fab_btn: "Рисуйте черновик на карте свободно, не тратя заряды",
+  popup_paint_guide: "Индикатор совпадения шаблона",
 };

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -601,4 +601,5 @@ export const viTranslations = {
   draft_brush: "Cọ vẽ",
   draft_map_lock: "Khóa bản đồ (kéo để vẽ)",
   hint_draft_fab_btn: "Vẽ nháp tự do trên bản đồ mà không tốn lượt",
+  popup_paint_guide: "Chỉ báo khớp mẫu",
 };

--- a/src/inject/bridge.ts
+++ b/src/inject/bridge.ts
@@ -14,6 +14,7 @@ import {
   handleColorFilterUpdate,
   handleCacheClear,
   handleFrontTileLayerUpdate,
+  handlePaintGuideUpdate,
   handleTransparentPixelFilterUpdate,
   handleSnapshotCaptureUpdate,
 } from "./handlers/state-handlers";
@@ -393,6 +394,7 @@ const messageHandlers: Record<string, MessageHandler> = {
     data.enabled ? startArtCruise(data) : stopArtCruise(),
   "mr-wplace-cache-clear": handleCacheClear,
   "mr-wplace-front-tile-layer-update": handleFrontTileLayerUpdate,
+  "mr-wplace-paint-guide-update": handlePaintGuideUpdate,
   "mr-wplace-transparent-pixel-filter-update":
     handleTransparentPixelFilterUpdate,
   "mr-wplace-snapshot-capture-update": handleSnapshotCaptureUpdate,

--- a/src/inject/features/paint-stats-updater.ts
+++ b/src/inject/features/paint-stats-updater.ts
@@ -127,7 +127,9 @@ export const handlePaintForStats = (
   const paintedRgbKey = `${(paintedRgbInt >> 16) & 0xff},${
     (paintedRgbInt >> 8) & 0xff
   },${paintedRgbInt & 0xff}`;
-  const guideEnabled = window.mrWplaceFrontTileLayerEnabled === true;
+  const guideEnabled =
+    window.mrWplaceFrontTileLayerEnabled === true &&
+    window.mrWplacePaintGuideEnabled !== false;
 
   const tileKey = `${coord.tileX},${coord.tileY}`;
   const paddedTileKey = toPaddedTileKey(coord.tileX, coord.tileY);

--- a/src/inject/handlers/state-handlers.ts
+++ b/src/inject/handlers/state-handlers.ts
@@ -5,6 +5,7 @@ import {
   setFrontTileLayerEnabled,
   refreshFrontTileLayer,
   setTransparentPixelFilterEnabled,
+  clearFrontTilePaintGuideAll,
 } from "../features/map-instance";
 
 const COLOR_FILTER_REFRESH_DEBOUNCE_MS = 120;
@@ -175,6 +176,15 @@ export const handleFrontTileLayerUpdate = (data: {
   window.mrWplaceFrontTileLayerEnabled = data.enabled;
   setFrontTileLayerEnabled(data.enabled);
   console.log("🧑‍🎨 : Front tile layer updated:", data.enabled);
+};
+
+/**
+ * Handle paint guide (template match indicator) toggle update
+ */
+export const handlePaintGuideUpdate = (data: { enabled: boolean }): void => {
+  window.mrWplacePaintGuideEnabled = data.enabled;
+  if (!data.enabled) clearFrontTilePaintGuideAll();
+  console.log("🧑‍🎨 : Paint guide indicator updated:", data.enabled);
 };
 
 export const handleTransparentPixelFilterUpdate = (data: {

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -85,6 +85,9 @@ const forceStartupLocationZoom = (): void => {
   // Initialize front tile layer (experimental, default: false)
   window.mrWplaceFrontTileLayerEnabled = false;
 
+  // Initialize paint guide indicator (template match/mismatch dots, default: on)
+  window.mrWplacePaintGuideEnabled = true;
+
   // Initialize transparent pixel filter (default: false)
   window.mrWplaceTransparentPixelFilterEnabled = false;
 

--- a/src/inject/types.ts
+++ b/src/inject/types.ts
@@ -183,6 +183,7 @@ declare global {
     mrWplaceOverlayLightweightMode?: boolean;
     mrWplaceSelectedColorOnlyMark?: boolean;
     mrWplaceFrontTileLayerEnabled?: boolean;
+    mrWplacePaintGuideEnabled?: boolean;
     mrWplaceTransparentPixelFilterEnabled?: boolean;
     mrWplaceSnapshotCaptureEnabled?: boolean;
     mrWplaceTempPaintedByUser?: PaintedByUser;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -35,6 +35,11 @@ import {
   setCloseButtonBig,
 } from "./states/close-button-big";
 import {
+  loadPaintGuideFromStorage,
+  getPaintGuide,
+  setPaintGuide,
+} from "./states/paint-guide";
+import {
   loadFabVisibilityFromStorage,
   getFabVisibility,
   setFabVisibility,
@@ -147,6 +152,7 @@ const updateUI = (): void => {
     "popup-paint-mode-style-label": "popup_paint_mode_style",
     "popup-hide-my-location-label": "popup_hide_my_location",
     "popup-close-button-big-label": "popup_close_button_big",
+    "popup-paint-guide-label": "popup_paint_guide",
     "popup-bug-report-label": "popup_bug_report",
     "popup-fab-visibility-label": "popup_fab_visibility",
     "popup-fab-gallery-label": "popup_fab_gallery",
@@ -307,6 +313,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       loadHideMyLocationFromStorage(),
       loadCloseButtonBigFromStorage(),
       loadFabVisibilityFromStorage(),
+      loadPaintGuideFromStorage(),
     ]);
 
     currentMode = getNavigationMode();
@@ -351,6 +358,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   setupToggle("close-button-big-toggle", getCloseButtonBig(), async (v) => {
     await setCloseButtonBig(v);
     await reloadActiveTab();
+  });
+
+  // Paint guide indicator (live update, no reload needed)
+  setupToggle("paint-guide-toggle", getPaintGuide(), async (v) => {
+    await setPaintGuide(v);
+    await notifyContentScriptBestEffort({ type: "PAINT_GUIDE_CHANGED", enabled: v });
   });
 
   // FAB visibility toggles

--- a/src/states/paint-guide.ts
+++ b/src/states/paint-guide.ts
@@ -1,0 +1,19 @@
+import { storage } from "@/utils/browser-api";
+
+const STORAGE_KEY = "paint-guide-enabled";
+
+let paintGuideEnabled = true;
+
+export const loadPaintGuideFromStorage = async (): Promise<void> => {
+  const result = await storage.get([STORAGE_KEY]);
+  paintGuideEnabled = result[STORAGE_KEY] !== false;
+};
+
+export const getPaintGuide = (): boolean => {
+  return paintGuideEnabled;
+};
+
+export const setPaintGuide = async (enabled: boolean): Promise<void> => {
+  paintGuideEnabled = enabled;
+  await storage.set({ [STORAGE_KEY]: enabled });
+};


### PR DESCRIPTION
Adds a popup setting to independently show/hide the mismatch/overflow guide dots during painting, default on, separate from other UI toggles.